### PR TITLE
support DetailType match and convert event

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ custom:
   serverless-offline-aws-eventbridge:
     port: 4010 # port to run the eventbridge mock server on
     debug: false # flag to show debug messages
+    account: '' # account id that gets passed to the event
+    convertEntry: false # flag to convert entry to match cloudwatch
 ```
 
 ## Publishing and subscribing
@@ -95,6 +97,30 @@ The events handler with two functions (publish and consume)
 
   export const consume = async (event, context) => {
     console.log(event);
+    /*
+      {
+        EventBusName: 'marketing',
+        Source: 'acme.newsletter.campaign',
+        DetailType: 'UserSignUp',
+        Detail: `{ "E-Mail": "some@someemail.some" }`,
+      }
+
+      * If 'convertEvent' flag is true, out output will be
+      {
+        version: "0",
+        id: "xxxxxxxx-xxxx-xxxx-xxxx-1234443234563",
+        source: "acme.newsletter.campaign",
+        account: "",
+        time: "2020-06-19T16:37:00Z",
+        region: "us-east-1",
+        resources: [],
+        detail: {
+          { 
+            "E-Mail": "some@someemail.some" 
+          }
+        }
+      }
+    */
     return { statusCode: 200, body: JSON.stringify(event) };
   }
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The events handler with two functions (publish and consume)
         Detail: `{ "E-Mail": "some@someemail.some" }`,
       }
 
-      * If 'convertEvent' flag is true, out output will be
+      * If 'convertEntry' flag is true, out output will be
       {
         version: "0",
         id: "xxxxxxxx-xxxx-xxxx-xxxx-1234443234563",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-aws-eventbridge",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Serverless plugin to run eventbridge offline.",
   "main": "src/index.js",
   "author": "Ruben Kaiser",


### PR DESCRIPTION
- added check for fn.events due to another plugin that didnt have an events property
-  `subscribedChecks.push(subscriber.event.pattern['detail-type'].includes(entry.DetailType));` was added because I noticed that all consumers were being fired. I'm sure there is a better way to do this to match AWS Eventbridge pattern matching. Open to suggestions
-  added `convertEntryToEvent()` because I noticed the events didn't match what's in CloudWatch which is then passed to a consuming lambda function. Considered adding a way to do a custom map. Also open to suggestions
- All changes should be backwards compatible 