### PR TITLE
Enable detail checking and support callback handler shape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,15 @@ class ServerlessOfflineAwsEventbridgePlugin {
               .map(async subscriber => {
                 const handler = this.createHandler(subscriber.functionName, subscriber.function);
                 const event = this.convertEntryToEvent(entry);
-                await handler()(event, {});
+                await handler()(event, {}, (err, success) => {
+                  if (this.debug) {
+                    if (err) {
+                      this.serverless.cli.log(`serverless-offline-aws-eventbridge ::`, `Error:`, err)
+                    } else {
+                      this.serverless.cli.log(`serverless-offline-aws-eventbridge ::`, success)
+                    }
+                  }
+                });
             });
           })
         );
@@ -111,6 +119,13 @@ class ServerlessOfflineAwsEventbridgePlugin {
 
     if (entry.DetailType && subscriber.event.pattern['detail-type']) {
       subscribedChecks.push(subscriber.event.pattern['detail-type'].includes(entry.DetailType));
+    }
+
+    if (entry.Detail && subscriber.event.pattern['detail']) {
+      const detail = JSON.parse(entry.Detail)
+      Object.keys(subscriber.event.pattern['detail']).forEach((key) => {
+        subscribedChecks.push(subscriber.event.pattern['detail'][key].includes(detail[key]))
+      }) 
     }
     
     const subscribed = subscribedChecks.every(x => x);


### PR DESCRIPTION
### Change 1:

Check the top-level keys of the Detail object and compare against the pattern. Note: This will not do a deep compare, just the top-level keys.

### Change 2:

Sometimes event handlers are implemented in the `(event, context, callback)` pattern, whereas the handler only sent in a fake context, without a fake callback. This change adds that callback, it also logs the output if the debug flag is set in the config.