### PR TITLE
add support for rate(...) schedules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,23 +27,45 @@ class ServerlessOfflineAwsEventbridgePlugin {
       if (fn.events) {
         fn.events.filter(event => event.eventBridge != null).map(event => {
           if(event.eventBridge.schedule) {
+            let convertedSchedule;
+
             if (event.eventBridge.schedule.indexOf('rate') > -1){
-              // TODO: convert rate to cron job
-              this.serverless.cli.log(`serverless-offline-aws-eventbridge ::`, 'unsupported rate used in scheduler');
+              const rate = event.eventBridge.schedule
+                .replace("rate(", "")
+                .replace(")", "");
+
+              const parts = rate.split(" ");
+
+              if (parts[1]) {
+                if (parts[1].startsWith("minute")) {
+                  convertedSchedule = `*/${parts[0]} * * * *`;
+                } else if (parts[1].startsWith("hour")) {
+                  convertedSchedule = `0 */${parts[0]} * * *`;
+                } else if (parts[1].startsWith("day")) {
+                  convertedSchedule = `0 0 */${parts[0]} * *`;
+                } else {
+                  this.serverless.cli.log(`serverless-offline-aws-eventbridge :: Invalid schedule rate syntax '${rate}', will not schedule`);
+                }
+              }
             } else {
               // get the cron job syntax right: cron(0 5 * * ? *)
               //
               //      min     hours       dayOfMonth  Month       DayOfWeek   Year        (AWS)
               // sec  min     hour        dayOfMonth  Month       DayOfWeek               (node-cron)
               // seconds is optional so we don't use it with node-cron
-              let convertedSchedule = `${event.eventBridge.schedule.substring(5, event.eventBridge.schedule.length-3)}`;
+              convertedSchedule = `${event.eventBridge.schedule.substring(5, event.eventBridge.schedule.length-3)}`;
               // replace ? by * for node-cron
               convertedSchedule = convertedSchedule.split('?').join('*');
+            }
+            if (convertedSchedule) {
               scheduled.push({
                 schedule: convertedSchedule,
                 functionName: fnName,
                 function: fn
               });
+            }
+            else {
+              this.serverless.cli.log(`serverless-offline-aws-eventbridge :: Invalid schedule syntax '${event.eventBridge.schedule}', will not schedule`);
             }
           } else {
             subscribers.push({ event: event.eventBridge, functionName: fnName, function: fn });

--- a/src/index.js
+++ b/src/index.js
@@ -31,20 +31,20 @@ class ServerlessOfflineAwsEventbridgePlugin {
 
             if (event.eventBridge.schedule.indexOf('rate') > -1){
               const rate = event.eventBridge.schedule
-                .replace("rate(", "")
-                .replace(")", "");
+                .replace('rate(', '')
+                .replace(')', '');
 
-              const parts = rate.split(" ");
+              const parts = rate.split(' ');
 
               if (parts[1]) {
-                if (parts[1].startsWith("minute")) {
+                if (parts[1].startsWith('minute')) {
                   convertedSchedule = `*/${parts[0]} * * * *`;
-                } else if (parts[1].startsWith("hour")) {
+                } else if (parts[1].startsWith('hour')) {
                   convertedSchedule = `0 */${parts[0]} * * *`;
-                } else if (parts[1].startsWith("day")) {
+                } else if (parts[1].startsWith('day')) {
                   convertedSchedule = `0 0 */${parts[0]} * *`;
                 } else {
-                  this.serverless.cli.log(`serverless-offline-aws-eventbridge :: Invalid schedule rate syntax '${rate}', will not schedule`);
+                  this.log(`Invalid schedule rate syntax '${rate}', will not schedule`);
                 }
               }
             } else {
@@ -65,7 +65,7 @@ class ServerlessOfflineAwsEventbridgePlugin {
               });
             }
             else {
-              this.serverless.cli.log(`serverless-offline-aws-eventbridge :: Invalid schedule syntax '${event.eventBridge.schedule}', will not schedule`);
+              this.log(`Invalid schedule syntax '${event.eventBridge.schedule}', will not schedule`);
             }
           } else {
             subscribers.push({ event: event.eventBridge, functionName: fnName, function: fn });


### PR DESCRIPTION
Works for me, but one odd thing... 

I can use the scheduler with config like this: 

```
        events:
        -   schedule:
                name: kickOffExtracts
                description: Kick off extracts from back ends that are due
                rate: rate(${env:SDPO_EXTRACT_RATE, 5} minutes)
```

but equivalent config for event bridge doesn't get the variables substituted:

```
        events:
        -   eventBridge:
              name: kickOffExtracts
              description: Kick off extracts from back ends that are due
              schedule: rate(${env:SDPO_EXTRACT_RATE, 5} minutes)
```

I haven't figured out how the variables get substituted in serverless.yml yet