### PR TITLE
fix: log function typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ class ServerlessOfflineAwsEventbridgePlugin {
 
     const subscribed = subscribedChecks.every((x) => x);
     this.log(
-      `${subscriber.functionName} ${subscribed ? "is" : "is not"} subscribed`
+      `${subscriber.functionKey} ${subscribed ? "is" : "is not"} subscribed`
     );
     return subscribed;
   }


### PR DESCRIPTION
fixed event handler subscribe log message to output function name instead of undefined.

`Serverless: serverless-offline-aws-eventbridge :: undefined is subscribed`