### PR TITLE
fix: flattenObject always return empty object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,24 +254,17 @@ class ServerlessOfflineAwsEventbridgePlugin {
     }
   }
 
-  flattenObject(obj) {
-    const flattened = {};
-    for (const i in obj) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (!obj.hasOwnProperty(i)) {
-        if (typeof obj[i] === "object" && !Array.isArray(obj[i])) {
-          const flatObject = this.flattenObject(obj[i]);
-          for (const x in flatObject) {
-            // eslint-disable-next-line no-prototype-builtins
-            if (!flatObject.hasOwnProperty(x))
-              flattened[`${i}.${x}`] = flatObject[x];
-          }
-        } else {
-          flattened[i] = obj[i];
-        }
-      }
-    }
-    return flattened;
+  flattenObject(object, prefix = "") {
+    return Object.entries(object).reduce(
+      (accumulator, [key, value]) =>
+        value && value instanceof Object && !(value instanceof Date)
+          ? {
+              ...accumulator,
+              ...this.flattenObject(value, (prefix && prefix + ".") + key),
+            }
+          : { ...accumulator, [(prefix && prefix + ".") + key]: value },
+      {}
+    );
   }
 
   log(message) {


### PR DESCRIPTION
**Note: I accidentally opened #20 in the wrong branch. This is the exact same but open from my appropriate local branch.**

According to the version 1.4.1. I've tested and found that `flattenObject` always return the empty object `{}`. This is because the condition `if(!obj.hasOwnProperty(i))` is never true for properties `i` in `obj`.