### PR TITLE
feat: retry lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ custom:
     debug: false # flag to show debug messages
     account: '' # account id that gets passed to the event
     maximumRetryAttempts: 10 # maximumRetryAttempts to retry lambda
+    retryDelayMs: 500 # retry delay
 ```
 
 ## Publishing and subscribing

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ plugins:
 
 Configuring the plugin
 
+optional options shown with defaults
 ```YAML
 custom:
   serverless-offline-aws-eventbridge:
     port: 4010 # port to run the eventbridge mock server on
     debug: false # flag to show debug messages
     account: '' # account id that gets passed to the event
+    maximumRetryAttempts: 10 # maximumRetryAttempts to retry lambda
 ```
 
 ## Publishing and subscribing


### PR DESCRIPTION
Add the ability to retry lambda functions, default is to retry 10 times waiting 500ms.

This doesn't try to mimic the behavior in AWS, but adds a simply retry with a configurable max.

PS. I didn't use [promise-retry](https://github.com/IndigoUnited/node-promise-retry) because of both out of date dependencies and that we don't need all the extra random ability that it provides.