### PR TITLE
fix: key.0, key.1 for event detail array matching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,10 @@ class ServerlessOfflineAwsEventbridgePlugin {
   flattenObject(object, prefix = "") {
     return Object.entries(object).reduce(
       (accumulator, [key, value]) =>
-        value && value instanceof Object && !(value instanceof Date)
+        value &&
+        value instanceof Object &&
+        !(value instanceof Date) &&
+        !Array.isArray(value)
           ? {
               ...accumulator,
               ...this.flattenObject(value, (prefix && `${prefix}.`) + key),


### PR DESCRIPTION
the event detail matching is broken for arrays, the array index was added to the key because of Object.entries.

This pr fixes that.

