### PR TITLE
Added support for eventBridge content-based filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ bower_components
 # node-waf configuration
 .lock-wscript
 
+# IntelliJ's project metadata
+.idea
+
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,34 @@ The events handler with two functions (publish and consume)
     return { statusCode: 200, body: 'scheduled event' };
   }
 ```
+## Support of EventBridge patterns
+
+EventBridge natively allows a few content-based filters defined here:
+https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html
+
+This plugin supports the most common patterns:
+* `prefix`
+* `anything-but`
+* `exists`
+
+```yaml
+functions:
+  consumeEvent:
+    handler: events.consume
+    events:
+      - eventBridge:
+          eventBus: marketing
+          pattern:
+            source:
+              - user
+            detail-type:
+              - { "anything-but": "deleted" }
+            detail:
+              firstname: [ { "prefix": "John" } ]
+              age: [ { "exists": true } ]
+```
+
+The `cidr` and `numeric` filters are yet to be implemented.
 
 ## Using CloudFormation intrinsic functions
 


### PR DESCRIPTION
This PR introduces support for eventBridge content-based filters, as per described in https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html

Please refer to documentation update for implementation details/examples.

Also my own use case:
```yaml
functions:
  changeListener:
    name: changeListener
    handler: src/sync.handle
    events:
      - eventBridge:
          eventBus: main
          pattern:
            source:
              - dynamodb.stream
            detail:
              dynamodb:
                Keys:
                  pk:
                    S: [ { "prefix": "USER#" } ]
```