### PR TITLE
Fix event filters when trying to match with "false" as an expected value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ class ServerlessOfflineAwsEventbridgePlugin {
   verifyIfValueMatchesEventBridgePattern(object, field, pattern) {
     // Simple scalar comparison
     if (typeof pattern !== "object") {
-      if (!object[field]) {
+      if (!(field in object)) {
         return false; // Scalar vs non-existing field => false
       }
       if (Array.isArray(object[field])) {


### PR DESCRIPTION
Fix event filters when trying to match with "false" as an expected value