### PR TITLE
Match the payload limit for json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class ServerlessOfflineAwsEventbridgePlugin {
     // initialise the express app
     this.app = express();
     this.app.use(cors());
-    this.app.use(bodyParser.json({ type: "application/x-amz-json-1.1" }));
+    this.app.use(bodyParser.json({ type: "application/x-amz-json-1.1", limit: "10mb" }));
     this.app.use(bodyParser.urlencoded({ extended: true, limit: "10mb" }));
     this.app.use((req, res, next) => {
       res.header("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Json payloads are limited to the default 100kb limit defined by `bodyParser`. 

There is an argument that both limits should be set to the 256kb limit enforced by aws for event bridge message payloads.