### PR TITLE
Support custom hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ custom:
   serverless-offline-aws-eventbridge:
     port: 4010 # port to run the eventBridge mock server on
     mockEventBridgeServer: true # Set to false if EventBridge is already mocked by another stack
+    hostname: 127.0.0.1 # IP or hostname of existing EventBridge if mocked by another stack
     pubSubPort: 4011 # Port to run the MQ server (or just listen if using an EventBridge Mock server from another stack)
     debug: false # flag to show debug messages
     account: '' # account id that gets passed to the event
@@ -194,12 +195,15 @@ custom:
   serverless-offline-aws-eventbridge:
     port: 4010 # port to run the eventBridge mock server on
     mockEventBridgeServer: true # Set to false if EventBridge is already mocked by another stack
+    hostname: 127.0.0.1 # IP or hostname of existing EventBridge if mocked by another stack
     pubSubPort: 4011 # Port to run the MQ server (or just listen if using an EventBridge mock server from another stack)
     debug: false # flag to show debug messages
     account: '' # account id that gets passed to the event
     imported-event-buses:
       EventBusNameFromOtherStack: event-bus-name-or-arn
 ```
+
+If your existing EventBridge is mocked on a different host/IP (e.g. When stacks are hosted in Docker containers), then you will also need to specify a `hostname`. If using Docker, you should use the name of the container that mocks the EventBridge (assuming both containers are on the same Docker network).
 
 ## Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "serverless-offline-aws-eventbridge",
-  "version": "1.5.2",
-
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-offline-aws-eventbridge",
-      "version": "1.5.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "aedes": "^0.46.0",
-        "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "mqtt": "^4.2.6"
@@ -14627,9 +14625,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -15628,12 +15626,6 @@
       "requires": {
         "p-defer": "^1.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-aws-eventbridge",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "description": "Serverless plugin to run eventbridge offline.",
   "main": "src/index.js",
   "author": "Ruben Kaiser",


### PR DESCRIPTION
We're using Docker container to run our stacks locally and we have the issue that each container is placed on its own IP address within the Docker network. This means that the default hostname of `127.0.0.1` does not work and the second stack cannot connect to the existing mock EventBridge.

This PR simply adds a `hostname` config option to allow the user to specify the hostname that it should connect to.

I wasn't sure how you deal with versioning as the `package.json` and `package-lock.json` were a little behind. I've updated them both to `1.6.3`. Please let me know if I should change this. Thanks!