### PR TITLE
prevents duplicate events when client reconnects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,11 @@ class ServerlessOfflineAwsEventbridgePlugin {
     this.mqClient = mqtt.connect(`mqtt://${this.hostname}:${this.pubSubPort}`);
 
     this.mqClient.on("connect", () => {
-      this.mqClient.subscribe("eventBridge", () => {
+      this.mqClient.subscribe("eventBridge", (err, granted) => {
+        // if the client is already subscribed, granted will be an empty array.
+        // This prevents duplicate message processing when the client reconnects
+        if (!granted || granted.length === 0) return;
+
         this.log(
           `MQTT broker connected and listening on mqtt://${this.hostname}:${this.pubSubPort}`
         );


### PR DESCRIPTION
This PR resolves an issue with processing duplicate events when the publisher and subscriber are in two different serverless projects, and the publisher rebuilds causing the MQTT client to reconnect. 

This PR now checks that the subscription has been granted, which will be empty in the case of a reconnection / resubscription. 