### PR TITLE
#43 break flow when handling errors in invokeSubscriber as it broke retris strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-aws-eventbridge",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Serverless plugin to run eventbridge offline.",
   "main": "src/index.js",
   "author": "Ruben Kaiser",

--- a/src/index.js
+++ b/src/index.js
@@ -251,6 +251,7 @@ class ServerlessOfflineAwsEventbridgePlugin {
         );
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
         await this.invokeSubscriber(functionKey, entry, retry + 1);
+        return;
       }
       this.log(
         `error: ${err} occurred in ${functionKey} on attempt ${retry}, max attempts reached`


### PR DESCRIPTION
Return added to break the exceptions handling. That prevents serverless-offline to break when some lambda function throws an error and enables back this plugin's retry strategy