### PR TITLE
fix: add throwRetryExhausted option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ custom:
     account: '' # account id that gets passed to the event
     maximumRetryAttempts: 10 # maximumRetryAttempts to retry lambda
     retryDelayMs: 500 # retry delay
+    throwRetryExhausted: false # default true
     payloadSizeLimit: "10mb" # Controls the maximum payload size being passed to https://www.npmjs.com/package/bytes (Note: this payload size might not be the same size as your AWS Eventbridge receive)
 ```
 


### PR DESCRIPTION
Add the ability to not throw when retries are exhausted.

Currently if the error is thrown the offline process will either crash if in process, or not handle future events if using worker threads.

This `PR` adds the ability to prevent the error being thrown.

This can be helpful when working locally to prevent process failure, and keeping the error handling in the functions the same as in production where DLQs may be deployed.