### PR TITLE
fix: check for array in anything-but

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -379,6 +379,9 @@ export default class ServerlessOfflineAwsEventbridgePlugin {
     }
 
     if ("anything-but" in pattern) {
+      if (Array.isArray(pattern['anything-but'])) {
+        return !pattern['anything-but'].includes(object[field]);
+      }
       return !this.verifyIfValueMatchesEventBridgePattern(
         object,
         field,


### PR DESCRIPTION
Currently the anything-but array causes the program to crash when sending an event bridge message. This is a problem because this behavior works in AWS, but not serverless-offline. Fix this by checking if the anything-but object is an array and returning whether the field is not in the array

### Error
``` shell
Error: The 0 eventBridge filter is not supported in serverless-offline-aws-eventBridge yet. Please consider submitting a PR to support it.
    at ServerlessOfflineAwsEventbridgePlugin.verifyIfValueMatchesEventBridgePattern (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:393:11)
    at ServerlessOfflineAwsEventbridgePlugin.verifyIfValueMatchesEventBridgePattern (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:373:20)
    at ServerlessOfflineAwsEventbridgePlugin.verifyIfValueMatchesEventBridgePatterns (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:343:16)
    at ServerlessOfflineAwsEventbridgePlugin.verifyIsSubscribed (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:315:18)
    at .../node_modules/serverless-offline-aws-eventbridge/src/index.js:228:14
    at Array.filter (<anonymous>)
    at ServerlessOfflineAwsEventbridgePlugin.invokeSubscribers (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:227:54)
    at MqttClient.<anonymous> (.../node_modules/serverless-offline-aws-eventbridge/src/index.js:104:39)
    at MqttClient.emit (events.js:400:28)
    at MqttClient.emit (domain.js:475:12)
    at MqttClient._handlePublish (.../node_modules/mqtt/lib/client.js:1547:12)
    at MqttClient._handlePacket (.../node_modules/mqtt/lib/client.js:535:12)
    at work (.../node_modules/mqtt/lib/client.js:438:12)
    at Writable.writable._write (.../node_modules/mqtt/lib/client.js:452:5)
    at doWrite (.../node_modules/readable-stream/lib/_stream_writable.js:409:139)
    at writeOrBuffer (.../node_modules/readable-stream/lib/_stream_writable.js:398:5)
    at Writable.write (.../node_modules/readable-stream/lib/_stream_writable.js:307:11)
    at Socket.ondata (internal/streams/readable.js:731:22)
    at Socket.emit (events.js:400:28)
    at Socket.emit (domain.js:475:12)
    at addChunk (internal/streams/readable.js:293:12)
    at readableAddChunk (internal/streams/readable.js:267:9)
    at Socket.Readable.push (internal/streams/readable.js:206:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
    at TCP.callbackTrampoline (internal/async_hooks.js:130:17)
```

### Code to Reproduce
``` yml
#serverless.yml
functions:
  publishEvent:
    handler: events.publish
    events:
      - http:
          path: publish
          method: post

  consumeEvent:
    handler: events.consume
    events:
      - eventBridge:
          eventBus: test
          pattern:
            detail:
              type:
                - anything-but:
                  - I
```

``` javascript
// events.js
import AWS from "aws-sdk";

export const publish = async () => {
  try {
    const eventBridge = new AWS.EventBridge({
      endpoint: "http://127.0.0.1:4010",
    });

    await eventBridge
      .putEvents({
        Entries: [
          {
            EventBusName: "test",
            Source: "test",
            DetailType: "Test",
            Detail: `{ "type": "C" }`,
          },
        ],
      })
      .promise();
    return { statusCode: 200, body: "published" };
  } catch (e) {
    console.error(e);
    return { statusCode: 400, body: "could not publish" };
  }
};

export const consume = async (event, context) => {
  console.log(event);
  return { statusCode: 200, body: JSON.stringify(event) };
};
```