### PR TITLE
Added support for equals-ignore-case filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -536,6 +536,10 @@ class ServerlessOfflineAwsEventBridgePlugin implements Plugin {
       return content.startsWith(pattern.prefix);
     }
 
+    if (filterType === 'equals-ignore-case') {
+      return content.toLowerCase() === pattern['equals-ignore-case'].toLowerCase();
+    }
+
     if ('numeric' in pattern) {
       // partition an array to be like [[">", 5], ["=",30]]
       const chunk: any = (arr = [], num = 2) => {


### PR DESCRIPTION
This PR addresses issue https://github.com/rubenkaiser/serverless-offline-eventBridge/issues/83. With this, `equals-ignore-case`, as documented in Amazon's [EventBridge User Guide](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html), is supported.
